### PR TITLE
Ensures tokenization and transcryption are null safe

### DIFF
--- a/carduus/token/crypto.py
+++ b/carduus/token/crypto.py
@@ -15,7 +15,9 @@ DEFAULT_NONCE = bytes([0] * 12)
 
 
 def make_deterministic_encrypter(key: bytes):
-    def encrypt(message: bytearray) -> bytes:
+    def encrypt(message: bytearray | None) -> bytes | None:
+        if not message:
+            return None
         from cryptography.hazmat.primitives.ciphers.aead import AESGCMSIV
 
         return AESGCMSIV(key).encrypt(DEFAULT_NONCE, bytes(message), None)
@@ -24,7 +26,9 @@ def make_deterministic_encrypter(key: bytes):
 
 
 def make_deterministic_decrypter(key: bytes):
-    def decrypt(message: bytearray) -> bytes:
+    def decrypt(message: bytearray | None) -> bytes | None:
+        if not message:
+            return None
         from cryptography.hazmat.primitives.ciphers.aead import AESGCMSIV
 
         return AESGCMSIV(key).decrypt(DEFAULT_NONCE, bytes(message), None)
@@ -33,7 +37,9 @@ def make_deterministic_decrypter(key: bytes):
 
 
 def make_asymmetric_encrypter(public_key: bytes):
-    def encrypt(message: bytearray) -> bytes:
+    def encrypt(message: bytearray | None) -> bytes | None:
+        if not message:
+            return None
         from cryptography.hazmat.primitives.serialization import load_pem_public_key
 
         key = load_pem_public_key(public_key)
@@ -51,7 +57,9 @@ def make_asymmetric_encrypter(public_key: bytes):
 
 
 def make_asymmetric_decrypter(private_key: bytes):
-    def decrypt(message: bytearray) -> bytes:
+    def decrypt(message: bytearray | None) -> bytes | None:
+        if not message:
+            return None
         from cryptography.hazmat.primitives.serialization import load_pem_private_key
 
         key = load_pem_private_key(private_key, None)

--- a/carduus/token/pii.py
+++ b/carduus/token/pii.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 
 from pyspark.sql import Column, DataFrame
 from pyspark.sql.functions import (
+    array,
+    array_join,
     col,
     when,
     year,
@@ -21,7 +23,7 @@ from pyspark.sql.types import (
     TimestampNTZType,
 )
 
-from carduus.token._impl import remap, normalize_text, first_char, metaphone
+from carduus.token._impl import null_safe, remap, normalize_text, first_char, metaphone
 
 
 class PiiTransform(ABC):
@@ -170,3 +172,8 @@ def enhance_pii(
             )
             new_pii = new_pii | set(enhancements.keys())
     return df.select(*all_columns), new_pii
+
+
+@null_safe
+def join_pii(*args: Column):
+    return array_join(array(*args), delimiter=":")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ def spark() -> SparkSession:
     # For PyArrow 2.0.0 and above, PYARROW_IGNORE_TIMEZONE environment variable must be set
     # to 1 (on the driver and executors).
     os.environ["PYARROW_IGNORE_TIMEZONE"] = "1"
-    return SparkSession.builder.appName("Carduus Tests").getOrCreate()
+    return SparkSession.Builder().appName("Carduus Tests").master("local[2]").getOrCreate()
 
 
 # These encryption keys are left hardcoded so that we can use tests to ensure stability


### PR DESCRIPTION
Previously the behavior of nulls in the raw PII would create unexpected behavior. The nulls were implicitly filtered out of the arrays of PII text while joining into a single PII string (directly before hashing). This resulted in a token being generated over only the non-null PII fields. 

This behavior may be desirable in some scenarios, but if it were to become an official part of the protocol it would need to be possible for users to know which tokens were impacted by missing PII. This is left for a future design discussion and PR.

For transcryption, null tokens were previously producing a runtime error. After this PR they will produce a null ephemeral token.