### PR TITLE
Removes newlines from tokens and ephemeral tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 The open source implementation of the Open Privacy Preserving Record Linkage (OPPRL) protocol build on Spark.
 
+> :warning: Carduus has not reached a v1.0 release yet and therefore the API and behaviors are subject to change. See the [contributing](../CONTRIBUTING.md) guide if you would like to help the project.
+
 ## Rationale
 
 Privacy Preserving Record Linkage (PPRL) is crucial component to data de-identification systems. PPRL obfuscate identifying attributes or other sensitive information about the subjects described in the records of a dataset while still preserving the ability to link records pertaining to the same subject through the use of an encrypted token. This practice is sometimes referred to as "tokenization" and is one of the components of data de-identification.

--- a/carduus/token/__init__.py
+++ b/carduus/token/__init__.py
@@ -3,7 +3,17 @@ from dataclasses import dataclass
 from typing import Iterable
 from enum import Enum
 from pyspark.sql import DataFrame
-from pyspark.sql.functions import col, lit, sha2, udf, to_binary, base64
+from pyspark.sql.functions import (
+    col,
+    lit,
+    sha2,
+    udf,
+    to_binary,
+    base64,
+    array_join,
+    array,
+    replace,
+)
 from pyspark.sql.types import BinaryType
 from carduus.token.pii import (
     normalize_pii,
@@ -15,6 +25,7 @@ from carduus.token.pii import (
     DateTransform,
 )
 import carduus.token.crypto as crypto
+from carduus.token._impl import base64_no_newline
 from carduus.keys import derive_aes_key
 
 
@@ -117,6 +128,12 @@ class OpprlToken(Enum):
     )
 
 
+def peak(df: DataFrame, msg: str) -> DataFrame:
+    print(msg)
+    df.show(truncate=False)
+    return df
+
+
 def tokenize(
     df: DataFrame,
     pii_transforms: dict[str, PiiTransform | OpprlPii],
@@ -168,12 +185,16 @@ def tokenize(
         pii.withColumns(
             {t.name: join_pii(*[col(f) for f in sorted(t.fields)]) for t in tokens_}
         )
+        .transform(peak, "Joined")
         .withColumns(
             {
-                column: base64(encrypt(to_binary(sha2(col(column), 512), lit("hex"))))
+                column: base64_no_newline(
+                    encrypt(to_binary(sha2(col(column), 512), lit("hex")))
+                )
                 for column in token_columns
             }
         )
+        .transform(peak, "Encrypted")
         .drop(*new_pii_columns)
     )
 
@@ -211,7 +232,7 @@ def transcrypt_out(
     )
     return df.withColumns(
         {
-            column: base64(encrypt(decrypt(to_binary(col(column), lit("base64")))))
+            column: base64_no_newline(encrypt(decrypt(to_binary(col(column), lit("base64")))))
             for column in token_columns
         }
     )
@@ -244,7 +265,7 @@ def transcrypt_in(
     )
     return df.withColumns(
         {
-            column: base64(encrypt(decrypt(to_binary(col(column), lit("base64")))))
+            column: base64_no_newline(encrypt(decrypt(to_binary(col(column), lit("base64")))))
             for column in token_columns
         }
     )

--- a/carduus/token/_impl.py
+++ b/carduus/token/_impl.py
@@ -11,6 +11,8 @@ from pyspark.sql.functions import (
     regexp_replace,
     trim,
     udf,
+    base64,
+    replace,
 )
 from pyspark.sql.types import StringType
 
@@ -60,3 +62,13 @@ def null_safe(func):
         return result.otherwise(func(*args))
 
     return wrapper
+
+
+def base64_no_newline(col: Column) -> Column:
+    """The default behavior of Spark's base64 function adds newlines every 76 characters for parity with unix.
+    Although this behavior doesn't make tokens invalid, it is likely to cause issues with users working with CSV files
+    that contain tokens.
+
+    See: https://superuser.com/questions/1225134/why-does-the-base64-of-a-string-contain-n
+    """
+    return replace(base64(col), lit("\r\n"), lit(""))

--- a/carduus/token/crypto.py
+++ b/carduus/token/crypto.py
@@ -1,4 +1,3 @@
-import os
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -477,53 +477,57 @@ toml = ["tomli"]
 
 [[package]]
 name = "cryptography"
-version = "43.0.3"
+version = "44.0.1"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
-python-versions = ">=3.7"
+python-versions = "!=3.9.0,!=3.9.1,>=3.7"
 groups = ["main"]
 markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "cryptography-43.0.3-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bf7a1932ac4176486eab36a19ed4c0492da5d97123f1406cf15e41b05e787d2e"},
-    {file = "cryptography-43.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63efa177ff54aec6e1c0aefaa1a241232dcd37413835a9b674b6e3f0ae2bfd3e"},
-    {file = "cryptography-43.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e1ce50266f4f70bf41a2c6dc4358afadae90e2a1e5342d3c08883df1675374f"},
-    {file = "cryptography-43.0.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:443c4a81bb10daed9a8f334365fe52542771f25aedaf889fd323a853ce7377d6"},
-    {file = "cryptography-43.0.3-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:74f57f24754fe349223792466a709f8e0c093205ff0dca557af51072ff47ab18"},
-    {file = "cryptography-43.0.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9762ea51a8fc2a88b70cf2995e5675b38d93bf36bd67d91721c309df184f49bd"},
-    {file = "cryptography-43.0.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:81ef806b1fef6b06dcebad789f988d3b37ccaee225695cf3e07648eee0fc6b73"},
-    {file = "cryptography-43.0.3-cp37-abi3-win32.whl", hash = "sha256:cbeb489927bd7af4aa98d4b261af9a5bc025bd87f0e3547e11584be9e9427be2"},
-    {file = "cryptography-43.0.3-cp37-abi3-win_amd64.whl", hash = "sha256:f46304d6f0c6ab8e52770addfa2fc41e6629495548862279641972b6215451cd"},
-    {file = "cryptography-43.0.3-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:8ac43ae87929a5982f5948ceda07001ee5e83227fd69cf55b109144938d96984"},
-    {file = "cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:846da004a5804145a5f441b8530b4bf35afbf7da70f82409f151695b127213d5"},
-    {file = "cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f996e7268af62598f2fc1204afa98a3b5712313a55c4c9d434aef49cadc91d4"},
-    {file = "cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f7b178f11ed3664fd0e995a47ed2b5ff0a12d893e41dd0494f406d1cf555cab7"},
-    {file = "cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c2e6fc39c4ab499049df3bdf567f768a723a5e8464816e8f009f121a5a9f4405"},
-    {file = "cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e1be4655c7ef6e1bbe6b5d0403526601323420bcf414598955968c9ef3eb7d16"},
-    {file = "cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:df6b6c6d742395dd77a23ea3728ab62f98379eff8fb61be2744d4679ab678f73"},
-    {file = "cryptography-43.0.3-cp39-abi3-win32.whl", hash = "sha256:d56e96520b1020449bbace2b78b603442e7e378a9b3bd68de65c782db1507995"},
-    {file = "cryptography-43.0.3-cp39-abi3-win_amd64.whl", hash = "sha256:0c580952eef9bf68c4747774cde7ec1d85a6e61de97281f2dba83c7d2c806362"},
-    {file = "cryptography-43.0.3-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:d03b5621a135bffecad2c73e9f4deb1a0f977b9a8ffe6f8e002bf6c9d07b918c"},
-    {file = "cryptography-43.0.3-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a2a431ee15799d6db9fe80c82b055bae5a752bef645bba795e8e52687c69efe3"},
-    {file = "cryptography-43.0.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:281c945d0e28c92ca5e5930664c1cefd85efe80e5c0d2bc58dd63383fda29f83"},
-    {file = "cryptography-43.0.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:f18c716be16bc1fea8e95def49edf46b82fccaa88587a45f8dc0ff6ab5d8e0a7"},
-    {file = "cryptography-43.0.3-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:4a02ded6cd4f0a5562a8887df8b3bd14e822a90f97ac5e544c162899bc467664"},
-    {file = "cryptography-43.0.3-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:53a583b6637ab4c4e3591a15bc9db855b8d9dee9a669b550f311480acab6eb08"},
-    {file = "cryptography-43.0.3-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:1ec0bcf7e17c0c5669d881b1cd38c4972fade441b27bda1051665faaa89bdcaa"},
-    {file = "cryptography-43.0.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2ce6fae5bdad59577b44e4dfed356944fbf1d925269114c28be377692643b4ff"},
-    {file = "cryptography-43.0.3.tar.gz", hash = "sha256:315b9001266a492a6ff443b61238f956b214dbec9910a081ba5b6646a055a805"},
+    {file = "cryptography-44.0.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:bf688f615c29bfe9dfc44312ca470989279f0e94bb9f631f85e3459af8efc009"},
+    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd7c7e2d71d908dc0f8d2027e1604102140d84b155e658c20e8ad1304317691f"},
+    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:887143b9ff6bad2b7570da75a7fe8bbf5f65276365ac259a5d2d5147a73775f2"},
+    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:322eb03ecc62784536bc173f1483e76747aafeb69c8728df48537eb431cd1911"},
+    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:21377472ca4ada2906bc313168c9dc7b1d7ca417b63c1c3011d0c74b7de9ae69"},
+    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:df978682c1504fc93b3209de21aeabf2375cb1571d4e61907b3e7a2540e83026"},
+    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:eb3889330f2a4a148abead555399ec9a32b13b7c8ba969b72d8e500eb7ef84cd"},
+    {file = "cryptography-44.0.1-cp37-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:8e6a85a93d0642bd774460a86513c5d9d80b5c002ca9693e63f6e540f1815ed0"},
+    {file = "cryptography-44.0.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6f76fdd6fd048576a04c5210d53aa04ca34d2ed63336d4abd306d0cbe298fddf"},
+    {file = "cryptography-44.0.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6c8acf6f3d1f47acb2248ec3ea261171a671f3d9428e34ad0357148d492c7864"},
+    {file = "cryptography-44.0.1-cp37-abi3-win32.whl", hash = "sha256:24979e9f2040c953a94bf3c6782e67795a4c260734e5264dceea65c8f4bae64a"},
+    {file = "cryptography-44.0.1-cp37-abi3-win_amd64.whl", hash = "sha256:fd0ee90072861e276b0ff08bd627abec29e32a53b2be44e41dbcdf87cbee2b00"},
+    {file = "cryptography-44.0.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:a2d8a7045e1ab9b9f803f0d9531ead85f90c5f2859e653b61497228b18452008"},
+    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b8272f257cf1cbd3f2e120f14c68bff2b6bdfcc157fafdee84a1b795efd72862"},
+    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e8d181e90a777b63f3f0caa836844a1182f1f265687fac2115fcf245f5fbec3"},
+    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:436df4f203482f41aad60ed1813811ac4ab102765ecae7a2bbb1dbb66dcff5a7"},
+    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4f422e8c6a28cf8b7f883eb790695d6d45b0c385a2583073f3cec434cc705e1a"},
+    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:72198e2b5925155497a5a3e8c216c7fb3e64c16ccee11f0e7da272fa93b35c4c"},
+    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a46a89ad3e6176223b632056f321bc7de36b9f9b93b2cc1cccf935a3849dc62"},
+    {file = "cryptography-44.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:53f23339864b617a3dfc2b0ac8d5c432625c80014c25caac9082314e9de56f41"},
+    {file = "cryptography-44.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:888fcc3fce0c888785a4876ca55f9f43787f4c5c1cc1e2e0da71ad481ff82c5b"},
+    {file = "cryptography-44.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:00918d859aa4e57db8299607086f793fa7813ae2ff5a4637e318a25ef82730f7"},
+    {file = "cryptography-44.0.1-cp39-abi3-win32.whl", hash = "sha256:9b336599e2cb77b1008cb2ac264b290803ec5e8e89d618a5e978ff5eb6f715d9"},
+    {file = "cryptography-44.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:e403f7f766ded778ecdb790da786b418a9f2394f36e8cc8b796cc056ab05f44f"},
+    {file = "cryptography-44.0.1-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:1f9a92144fa0c877117e9748c74501bea842f93d21ee00b0cf922846d9d0b183"},
+    {file = "cryptography-44.0.1-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:610a83540765a8d8ce0f351ce42e26e53e1f774a6efb71eb1b41eb01d01c3d12"},
+    {file = "cryptography-44.0.1-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:5fed5cd6102bb4eb843e3315d2bf25fede494509bddadb81e03a859c1bc17b83"},
+    {file = "cryptography-44.0.1-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:f4daefc971c2d1f82f03097dc6f216744a6cd2ac0f04c68fb935ea2ba2a0d420"},
+    {file = "cryptography-44.0.1-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:94f99f2b943b354a5b6307d7e8d19f5c423a794462bde2bf310c770ba052b1c4"},
+    {file = "cryptography-44.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d9c5b9f698a83c8bd71e0f4d3f9f839ef244798e5ffe96febfa9714717db7af7"},
+    {file = "cryptography-44.0.1.tar.gz", hash = "sha256:f51f5705ab27898afda1aaa430f34ad90dc117421057782022edf0600bec5f14"},
 ]
 
 [package.dependencies]
 cffi = {version = ">=1.12", markers = "platform_python_implementation != \"PyPy\""}
 
 [package.extras]
-docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.1.1)"]
-docstest = ["pyenchant (>=1.6.11)", "readme-renderer", "sphinxcontrib-spelling (>=4.0.1)"]
-nox = ["nox"]
-pep8test = ["check-sdist", "click", "mypy", "ruff"]
-sdist = ["build"]
+docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=3.0.0)"]
+docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
+nox = ["nox (>=2024.4.15)", "nox[uv] (>=2024.3.2)"]
+pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.4)", "ruff (>=0.3.6)"]
+sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["certifi", "cryptography-vectors (==43.0.3)", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
+test = ["certifi (>=2024)", "cryptography-vectors (==44.0.1)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
@@ -2996,4 +3000,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "8fa55470348a7589a5d6df9e55005fe0f6dcc5eabd2c3be17c470c20a84ee280"
+content-hash = "e28a8619a7ada402069be86e3589cf8ab9015d922eb079c3681a442461451671"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{ include = "carduus" }]
 python = "^3.10"
 pyspark = "^3.5"
 jellyfish = "^1.0.3"
-cryptography = "^43.0.0"
+cryptography = "^44.0.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2"

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -58,9 +58,9 @@ def test_tokenize_and_transcrypt_opprl(
                         last_name="PASTEUR",
                         gender="M",
                         birth_date=date(1822, 12, 27),
-                        opprl_token_1="NJQZ0hNk40pt5aFitlwdx6k2Te7hMSMw1UHzNdgP1aUYbqaFbGSe3tRn4kL/OxsFJit9VhRDYRaw\r\nUDYzKivYlLm2EzKCO0+nC9rJXfIFwdo=",
-                        opprl_token_2="l6MNGG4InDZCnVX5/h3ajn1m1rCoko062CD8the2nkKO3Y0fARGZ5p4BP3pXPp3HOL603KCwpWLI\r\nXMN8fnsG3D4Tea/WOQX5kB1OQ28t2L0=",
-                        opprl_token_3="op48PUlod5WC7PMQHJp1wEtAApfgu/1G2WuGoVDMQ6V5EZPI7X5BfpZzrdoOrA90CFVw3X79t0yg\r\nazbSFrRKx+SupOvBYFRr8ZRZmT5oz8k=",
+                        opprl_token_1="NJQZ0hNk40pt5aFitlwdx6k2Te7hMSMw1UHzNdgP1aUYbqaFbGSe3tRn4kL/OxsFJit9VhRDYRawUDYzKivYlLm2EzKCO0+nC9rJXfIFwdo=",
+                        opprl_token_2="l6MNGG4InDZCnVX5/h3ajn1m1rCoko062CD8the2nkKO3Y0fARGZ5p4BP3pXPp3HOL603KCwpWLIXMN8fnsG3D4Tea/WOQX5kB1OQ28t2L0=",
+                        opprl_token_3="op48PUlod5WC7PMQHJp1wEtAApfgu/1G2WuGoVDMQ6V5EZPI7X5BfpZzrdoOrA90CFVw3X79t0ygazbSFrRKx+SupOvBYFRr8ZRZmT5oz8k=",
                     ),
                     Row(
                         id=2,
@@ -68,9 +68,9 @@ def test_tokenize_and_transcrypt_opprl(
                         last_name="PASTEUR",
                         gender="M",
                         birth_date=date(1822, 12, 27),
-                        opprl_token_1="NJQZ0hNk40pt5aFitlwdx6k2Te7hMSMw1UHzNdgP1aUYbqaFbGSe3tRn4kL/OxsFJit9VhRDYRaw\r\nUDYzKivYlLm2EzKCO0+nC9rJXfIFwdo=",
-                        opprl_token_2="l6MNGG4InDZCnVX5/h3ajn1m1rCoko062CD8the2nkKO3Y0fARGZ5p4BP3pXPp3HOL603KCwpWLI\r\nXMN8fnsG3D4Tea/WOQX5kB1OQ28t2L0=",
-                        opprl_token_3="op48PUlod5WC7PMQHJp1wEtAApfgu/1G2WuGoVDMQ6V5EZPI7X5BfpZzrdoOrA90CFVw3X79t0yg\r\nazbSFrRKx+SupOvBYFRr8ZRZmT5oz8k=",
+                        opprl_token_1="NJQZ0hNk40pt5aFitlwdx6k2Te7hMSMw1UHzNdgP1aUYbqaFbGSe3tRn4kL/OxsFJit9VhRDYRawUDYzKivYlLm2EzKCO0+nC9rJXfIFwdo=",
+                        opprl_token_2="l6MNGG4InDZCnVX5/h3ajn1m1rCoko062CD8the2nkKO3Y0fARGZ5p4BP3pXPp3HOL603KCwpWLIXMN8fnsG3D4Tea/WOQX5kB1OQ28t2L0=",
+                        opprl_token_3="op48PUlod5WC7PMQHJp1wEtAApfgu/1G2WuGoVDMQ6V5EZPI7X5BfpZzrdoOrA90CFVw3X79t0ygazbSFrRKx+SupOvBYFRr8ZRZmT5oz8k=",
                     ),
                 ]
             )
@@ -107,15 +107,15 @@ def test_tokenize_and_transcrypt_opprl(
                 [
                     Row(
                         id=1,
-                        opprl_token_1="U/JYKVLQWSUrpvJ1D03pvKmnhlgUTFjHaPtS0pZBLSqrDCOkBOR/mDf9xFt/Cr3AB8hI00oEkuun\r\nCTvNV3zbgdz9Y0jcwiI16zn51jSkhhM=",
-                        opprl_token_2="GDV/IQ0x6ZR/Gtl+nFOMOoKtTJ6gOHTvVJoaZZhP0BHUsymHbw+pyF9Cbjr0Q/Apa07wvN93CBnr\r\n4aBi8vvCDxi0Qg8x8wJf+yZZpwFR3Dw=",
-                        opprl_token_3="cOrhMGV6oO3Vt8w3vV1K4TzvNYlkZZ9JOj9/53IGkD7vgce0I13uOrDFCcJEXD1qEa4Mm1Nimq4s\r\nprd8tFrdDHRDCOeZBE2Gs4DEEt7LhL0=",
+                        opprl_token_1="U/JYKVLQWSUrpvJ1D03pvKmnhlgUTFjHaPtS0pZBLSqrDCOkBOR/mDf9xFt/Cr3AB8hI00oEkuunCTvNV3zbgdz9Y0jcwiI16zn51jSkhhM=",
+                        opprl_token_2="GDV/IQ0x6ZR/Gtl+nFOMOoKtTJ6gOHTvVJoaZZhP0BHUsymHbw+pyF9Cbjr0Q/Apa07wvN93CBnr4aBi8vvCDxi0Qg8x8wJf+yZZpwFR3Dw=",
+                        opprl_token_3="cOrhMGV6oO3Vt8w3vV1K4TzvNYlkZZ9JOj9/53IGkD7vgce0I13uOrDFCcJEXD1qEa4Mm1Nimq4sprd8tFrdDHRDCOeZBE2Gs4DEEt7LhL0=",
                     ),
                     Row(
                         id=2,
-                        opprl_token_1="U/JYKVLQWSUrpvJ1D03pvKmnhlgUTFjHaPtS0pZBLSqrDCOkBOR/mDf9xFt/Cr3AB8hI00oEkuun\r\nCTvNV3zbgdz9Y0jcwiI16zn51jSkhhM=",
-                        opprl_token_2="GDV/IQ0x6ZR/Gtl+nFOMOoKtTJ6gOHTvVJoaZZhP0BHUsymHbw+pyF9Cbjr0Q/Apa07wvN93CBnr\r\n4aBi8vvCDxi0Qg8x8wJf+yZZpwFR3Dw=",
-                        opprl_token_3="cOrhMGV6oO3Vt8w3vV1K4TzvNYlkZZ9JOj9/53IGkD7vgce0I13uOrDFCcJEXD1qEa4Mm1Nimq4s\r\nprd8tFrdDHRDCOeZBE2Gs4DEEt7LhL0=",
+                        opprl_token_1="U/JYKVLQWSUrpvJ1D03pvKmnhlgUTFjHaPtS0pZBLSqrDCOkBOR/mDf9xFt/Cr3AB8hI00oEkuunCTvNV3zbgdz9Y0jcwiI16zn51jSkhhM=",
+                        opprl_token_2="GDV/IQ0x6ZR/Gtl+nFOMOoKtTJ6gOHTvVJoaZZhP0BHUsymHbw+pyF9Cbjr0Q/Apa07wvN93CBnr4aBi8vvCDxi0Qg8x8wJf+yZZpwFR3Dw=",
+                        opprl_token_3="cOrhMGV6oO3Vt8w3vV1K4TzvNYlkZZ9JOj9/53IGkD7vgce0I13uOrDFCcJEXD1qEa4Mm1Nimq4sprd8tFrdDHRDCOeZBE2Gs4DEEt7LhL0=",
                     ),
                 ]
             )
@@ -187,8 +187,8 @@ def test_custom_pii_and_token(spark: SparkSession, private_key: bytes):
                         gender="F",
                         birth_date=date(1867, 11, 7),
                         zipcode="",
-                        custom_token="a4l0zaphD0cOzrrRAsQR4++7c91z+wrhZURjlUQszMHS2H82q5dUzYNmsPaVTHRDVtojQKkvKcj0\r\nziGvRBdKxoqp6b3KgkxAoN9EzbPGQJQ=",
-                        opprl_token_1="tqwyRFi77r48A2FRj6O3KmHm9btLa1dxJYn52DpdEy3OQ0j7iuvjwYgems1SFmfOqHJ5KnK7UxzM\r\nCi2TTaJWwbnho6J7TVvPhgkNU9U0ot4=",
+                        custom_token="a4l0zaphD0cOzrrRAsQR4++7c91z+wrhZURjlUQszMHS2H82q5dUzYNmsPaVTHRDVtojQKkvKcj0ziGvRBdKxoqp6b3KgkxAoN9EzbPGQJQ=",
+                        opprl_token_1="tqwyRFi77r48A2FRj6O3KmHm9btLa1dxJYn52DpdEy3OQ0j7iuvjwYgems1SFmfOqHJ5KnK7UxzMCi2TTaJWwbnho6J7TVvPhgkNU9U0ot4=",
                     ),
                     Row(
                         id=2,
@@ -197,8 +197,8 @@ def test_custom_pii_and_token(spark: SparkSession, private_key: bytes):
                         gender="M",
                         birth_date=date(1859, 5, 15),
                         zipcode="",
-                        custom_token="a4l0zaphD0cOzrrRAsQR4++7c91z+wrhZURjlUQszMHS2H82q5dUzYNmsPaVTHRDVtojQKkvKcj0\r\nziGvRBdKxoqp6b3KgkxAoN9EzbPGQJQ=",
-                        opprl_token_1="Ui78f0vu3cD01mdnP+1E1yt2Qn6AZu0oA1G2YbRWUBAnTvl6SO+s3cJsHlRkL40LR4IMSb+maEDa\r\n5J4ZgNxFD7agtt9wOE8NurHCIrmiRs8=",
+                        custom_token="a4l0zaphD0cOzrrRAsQR4++7c91z+wrhZURjlUQszMHS2H82q5dUzYNmsPaVTHRDVtojQKkvKcj0ziGvRBdKxoqp6b3KgkxAoN9EzbPGQJQ=",
+                        opprl_token_1="Ui78f0vu3cD01mdnP+1E1yt2Qn6AZu0oA1G2YbRWUBAnTvl6SO+s3cJsHlRkL40LR4IMSb+maEDa5J4ZgNxFD7agtt9wOE8NurHCIrmiRs8=",
                     ),
                     Row(
                         id=3,
@@ -207,8 +207,8 @@ def test_custom_pii_and_token(spark: SparkSession, private_key: bytes):
                         gender="M",
                         birth_date=date(1914, 10, 28),
                         zipcode="10016",
-                        custom_token="mbWIfUp4H/1QVWKF+aNuHfJfpUgnJrifZndPdVquuYcRiKJjG21jQ/71pAnlvDNjTNq3k0mxlKhW\r\nNaypvBc0ghNfmvS1mPfag6sr12dBu1I=",
-                        opprl_token_1="t+Yg6k4aOm5xMOMjT1nUCVbw1xM6mITKRx/APB+oU0dNo/AN2q/p20Pu2fiKd4wX5iFVK119DJAH\r\nYkFJYuI1BxgLBrzkiQKdEJKn1kMzA6k=",
+                        custom_token="mbWIfUp4H/1QVWKF+aNuHfJfpUgnJrifZndPdVquuYcRiKJjG21jQ/71pAnlvDNjTNq3k0mxlKhWNaypvBc0ghNfmvS1mPfag6sr12dBu1I=",
+                        opprl_token_1="t+Yg6k4aOm5xMOMjT1nUCVbw1xM6mITKRx/APB+oU0dNo/AN2q/p20Pu2fiKd4wX5iFVK119DJAHYkFJYuI1BxgLBrzkiQKdEJKn1kMzA6k=",
                     ),
                 ]
             )


### PR DESCRIPTION
This PR fixes #13. Tokens and ephemeral tokens will no longer contain newlines when PII is long.

This is a breaking change in tokens. Tokens generated after this change will not include the newline character and not match to tokens generated before this change. This breakage is considered acceptable because 1) we have not reached a v1.0 release yet as stated in our getting started guide and 2) users can easily update existing tokens when upgrading carduus by removing newline characters.