### PR TITLE
Adds new OPPRL tokens to spindle-token 

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -67,6 +67,12 @@ The spindle-token CLI requires specific column naming for PII columns so that th
 - `last_name`
 - `gender`
 - `birth_date`
+- `email`
+- `hem`
+- `phone`
+- `ssn`
+- `group_number`
+- `member_id`
 
 If you are only adding tokens that require a subset of these PII fields, the input dataset may omit columns for the other PII attributes that are not required. For information on which PII attributes are required for each token in the OPPRL protocol, see the official [specification](./opprl/PROTOCOL.md).
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1779,6 +1779,18 @@ files = [
 ptyprocess = ">=0.5"
 
 [[package]]
+name = "phonenumberslite"
+version = "9.0.12"
+description = "Python version of Google's common library for parsing, formatting, storing and validating international phone numbers."
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "phonenumberslite-9.0.12-py2.py3-none-any.whl", hash = "sha256:3ffa80e90c9b49c9c65e9028d3773d37481804bfd34a677d6f47d73bc4ce5ff4"},
+    {file = "phonenumberslite-9.0.12.tar.gz", hash = "sha256:af9bed605fc4a81a7045da184b88b21db2c8aa287ffcb75ff433df92566b2d46"},
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.3.6"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
@@ -2738,4 +2750,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "62100e6dc09535a9ac58a220054dfa59e54b12e34500bafb23c696913db51bce"
+content-hash = "d0c6d0438c3d140143694e771f2327fccaefde36bbe69ea61271103a9889cbd2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "jellyfish (>=1.0.3,<2.0.0)",
     "cryptography (>=44.0.1,<45.0.0)",
     "click (>=8.1.8,<9.0.0)",
+    "phonenumberslite (>=9.0.12,<10.0.0)",
 ]
 
 [project.scripts]

--- a/src/spindle_token/__init__.py
+++ b/src/spindle_token/__init__.py
@@ -73,10 +73,20 @@ def tokenize(
 
     protocols = _bound_protocols(tokens, private_key, public_key=None)
 
+    all_attrs_and_columns: dict[str, tuple[str, PiiAttribute]] = {}
+    for attr, column_name in col_mapping.items():
+        for derivate_id, derivate in attr.derivatives().items():
+            all_attrs_and_columns[derivate_id] = (column_name, derivate)
+
     token_columns = []
     for token in tokens:
+        attribute_columns = {}
+        for attr_id in token.attribute_ids:
+            col_name, attr = all_attrs_and_columns[attr_id]
+            attribute_columns[attr] = col_name
+
         protocol = protocols[token.protocol.factory_id]
-        token_column = protocol.tokenize(df, col_mapping, token.attributes).alias(token.name)
+        token_column = protocol.tokenize(df, attribute_columns).alias(token.name)
         token_columns.append(token_column)
 
     return df.select(col("*"), *token_columns)

--- a/src/spindle_token/_utils.py
+++ b/src/spindle_token/_utils.py
@@ -35,6 +35,10 @@ def null_if(pred: Callable[[Column], Column], col: Column) -> Column:
     return when(~pred(col), col).otherwise(lit(None))
 
 
+def empty_to_null(col: Column) -> Column:
+    return null_if(lambda c: length(c) == 0, col)
+
+
 def first_char(col: Column) -> Column:
     return substring(col, 1, 1)
 
@@ -48,7 +52,7 @@ metaphone = udf(_metaphone_udf_impl, returnType=StringType(), useArrow=False)
 
 def normalize_text(raw: Column) -> Column:
     """Some common text normalization used throughout OPPRL."""
-    return null_if(lambda c: length(c) == 0, trim(regexp_replace(upper(raw), "\\s+", " ")))
+    return empty_to_null(trim(regexp_replace(upper(raw), "\\s+", " ")))
 
 
 def null_propagating(func):

--- a/src/spindle_token/core.py
+++ b/src/spindle_token/core.py
@@ -91,7 +91,6 @@ class TokenProtocol(ABC):
         self,
         df: DataFrame,
         col_mapping: Mapping[PiiAttribute, str],
-        attributes: Iterable[PiiAttribute],
     ) -> Column: ...
 
     """Creates a Column expression for a single token.
@@ -184,11 +183,11 @@ class Token:
         protocol:
             An instance of `TokenProtocolFactory` that, when provided encryption keys, produced an instance of the
             `TokenProtocol` that generates this kind of token.
-        attributes:
-            A collection of `PiiAttribute` objects that denote the PII fields used to create the tokens.
+        attribute_ids:
+            A collection of attribute IDs used to lookup instances of `PiiAttribute` corresponding to the fields used to create the token.
 
     """
 
     name: str
     protocol: TokenProtocolFactory
-    attributes: Iterable[PiiAttribute]
+    attribute_ids: Iterable[str]

--- a/src/spindle_token/opprl/__init__.py
+++ b/src/spindle_token/opprl/__init__.py
@@ -8,5 +8,6 @@ the complete spec of the corresponding OPPRL version.
 
 from spindle_token.opprl.v0 import OpprlV0
 from spindle_token.opprl.v1 import OpprlV1
+from spindle_token.opprl._common import IdentityAttribute
 
-__all__ = ["OpprlV0", "OpprlV1"]
+__all__ = ["OpprlV0", "OpprlV1", "IdentityAttribute"]

--- a/src/spindle_token/opprl/v1.py
+++ b/src/spindle_token/opprl/v1.py
@@ -1,5 +1,5 @@
 from typing import ClassVar
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
 from pyspark.sql import DataFrame, Column
 from pyspark.sql.functions import udf
 from pyspark.sql.types import BinaryType
@@ -11,7 +11,17 @@ from spindle_token._crypto import (
     make_asymmetric_encrypter,
     make_asymmetric_decrypter,
 )
-from spindle_token.opprl._common import NameAttribute, GenderAttribute, DateAttribute
+from spindle_token.opprl._common import (
+    EmailAttribute,
+    GroupNumberAttribute,
+    HashedEmail,
+    MemberIdAttribute,
+    NameAttribute,
+    GenderAttribute,
+    DateAttribute,
+    PhoneNumberAttribute,
+    SsnAttribute,
+)
 import spindle_token.opprl.v0 as v0
 
 
@@ -36,9 +46,8 @@ class _ProtocolV1(TokenProtocol):
         self,
         df: DataFrame,
         col_mapping: Mapping[PiiAttribute, str],
-        attributes: Iterable[PiiAttribute],
     ) -> Column:
-        return v0._tokenize_impl(df, col_mapping, attributes, self.encrypt_aes)
+        return v0._tokenize_impl(df, col_mapping, self.encrypt_aes)
 
     def transcode_out(self, token: Column) -> Column:
         if not self.encrypt_rsa:
@@ -81,6 +90,27 @@ class OpprlV1:
             A token generated from first soundex, last soundex, gender, and birth date.
         token3:
             A token generated from first metaphone, last metaphone, gender, and birth date.
+        token4:
+            A token generated from first initial, last name, and birth date.
+        token5:
+            A token generated from first soundex, last soundex, and birth date.
+        token6:
+            A token generated from first metaphone, last metaphone, and birth date.
+        token7:
+            A token generated from first name and phone number.
+        token8:
+            A token generated from birth date and phone number.
+        token9:
+            A token generated from first name and SSN.
+        token10:
+            A token generated from birth date and SSN.
+        token11:
+            A token generated from an email address.
+        token12:
+            A token generated from a SHA2 hashed email address.
+        token13:
+            A token generated from health plan group number and member ID.
+
     """
 
     first_name: ClassVar[NameAttribute] = NameAttribute("opprl.v1.first")
@@ -91,16 +121,29 @@ class OpprlV1:
 
     birth_date: ClassVar[DateAttribute] = DateAttribute("opprl.v1.birth_date", "yyyy-MM-dd")
 
+    email: ClassVar[EmailAttribute] = EmailAttribute("opprl.v1.email")
+
+    # This class var should be used when the user's data has a HEM column and therefore we don't specify _parent.
+    hem: ClassVar[HashedEmail] = HashedEmail(email.sha2.attr_id)
+
+    phone: ClassVar[PhoneNumberAttribute] = PhoneNumberAttribute("opprl.v1.phone")
+
+    ssn: ClassVar[SsnAttribute] = SsnAttribute("opprl.v1.ssn")
+
+    group_number: ClassVar[GroupNumberAttribute] = GroupNumberAttribute("opprl.v1.group_number")
+
+    member_id: ClassVar[MemberIdAttribute] = MemberIdAttribute("opprl.v1.member_id")
+
     protocol: ClassVar[TokenProtocolFactory] = _ProtocolFactoryV1("opprl.v1")
 
     token1: ClassVar[Token] = Token(
         "opprl_token_1v1",
         protocol,
         (
-            first_name.initial,
-            last_name,
-            gender,
-            birth_date,
+            first_name.initial.attr_id,
+            last_name.attr_id,
+            gender.attr_id,
+            birth_date.attr_id,
         ),
     )
 
@@ -108,10 +151,10 @@ class OpprlV1:
         "opprl_token_2v1",
         protocol,
         (
-            first_name.soundex,
-            last_name.soundex,
-            gender,
-            birth_date,
+            first_name.soundex.attr_id,
+            last_name.soundex.attr_id,
+            gender.attr_id,
+            birth_date.attr_id,
         ),
     )
 
@@ -119,9 +162,96 @@ class OpprlV1:
         "opprl_token_3v1",
         protocol,
         (
-            first_name.metaphone,
-            last_name.metaphone,
-            gender,
-            birth_date,
+            first_name.metaphone.attr_id,
+            last_name.metaphone.attr_id,
+            gender.attr_id,
+            birth_date.attr_id,
+        ),
+    )
+
+    token4: ClassVar[Token] = Token(
+        "opprl_token_4v1",
+        protocol,
+        (
+            first_name.initial.attr_id,
+            last_name.attr_id,
+            birth_date.attr_id,
+        ),
+    )
+
+    token5: ClassVar[Token] = Token(
+        "opprl_token_5v1",
+        protocol,
+        (
+            first_name.soundex.attr_id,
+            last_name.soundex.attr_id,
+            birth_date.attr_id,
+        ),
+    )
+
+    token6: ClassVar[Token] = Token(
+        "opprl_token_6v1",
+        protocol,
+        (
+            first_name.metaphone.attr_id,
+            last_name.metaphone.attr_id,
+            birth_date.attr_id,
+        ),
+    )
+
+    token7: ClassVar[Token] = Token(
+        "opprl_token_7v1",
+        protocol,
+        (
+            first_name.attr_id,
+            phone.attr_id,
+        ),
+    )
+
+    token8: ClassVar[Token] = Token(
+        "opprl_token_8v1",
+        protocol,
+        (
+            birth_date.attr_id,
+            phone.attr_id,
+        ),
+    )
+
+    token9: ClassVar[Token] = Token(
+        "opprl_token_9v1",
+        protocol,
+        (
+            first_name.attr_id,
+            ssn.attr_id,
+        ),
+    )
+
+    token10: ClassVar[Token] = Token(
+        "opprl_token_10v1",
+        protocol,
+        (
+            birth_date.attr_id,
+            ssn.attr_id,
+        ),
+    )
+
+    token11: ClassVar[Token] = Token(
+        "opprl_token_11v1",
+        protocol,
+        (email.attr_id,),
+    )
+
+    token12: ClassVar[Token] = Token(
+        "opprl_token_12v1",
+        protocol,
+        (hem.attr_id,),
+    )
+
+    token13: ClassVar[Token] = Token(
+        "opprl_token_13v1",
+        protocol,
+        (
+            group_number.attr_id,
+            member_id.attr_id,
         ),
     )

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -1,52 +1,83 @@
 import pytest
 from datetime import date
 from pyspark.sql import SparkSession, Row
-from pyspark.sql.types import StructType, StructField, LongType, StringType, DateType
+from pyspark.sql.types import StructType, StructField, StringType, DateType
 from pyspark.sql.functions import regexp_replace, substring
 from pyspark.testing.utils import assertDataFrameEqual, assertSchemaEqual
 from spindle_token import tokenize, transcode_out, transcode_in
 from spindle_token._crypto import _PRIVATE_KEY_ENV_VAR, _RECIPIENT_PUBLIC_KEY_ENV_VAR
 from spindle_token.core import PiiAttribute, Token
-from spindle_token.opprl.v0 import OpprlV0 as v0
-from spindle_token.opprl.v1 import OpprlV1 as v1
+from spindle_token.opprl import OpprlV0 as v0, OpprlV1 as v1, IdentityAttribute
 
 
 def test_tokenize_and_transcode_opprl(
     spark: SparkSession, private_key: bytes, acme_public_key: bytes, acme_private_key: bytes
 ):
-    all_tokens = [v0.token1, v0.token2, v0.token3, v1.token1, v1.token2, v1.token3]
+    all_tokens = [
+        v0.token1,
+        v0.token2,
+        v0.token3,
+        v1.token1,
+        v1.token2,
+        v1.token3,
+        v1.token4,
+        v1.token5,
+        v1.token6,
+        v1.token7,
+        v1.token8,
+        v1.token9,
+        v1.token10,
+        v1.token11,
+        v1.token12,
+        v1.token13,
+    ]
     all_token_names = [token.name for token in all_tokens]
 
     pii = spark.createDataFrame(
         [
             Row(
-                id=1,
                 first_name="Louis",
                 last_name="Pasteur",
                 gender="male",
                 birth_date="1822-12-27",
+                email="lpasteur@notareal.email",
+                phone="(234) 555-7890",
+                ssn="666-12-3456",  # 666 is invalid
+                group_number="FAKE123",
+                member_id="12345",
             ),
             Row(
-                id=2,
                 first_name="louis",
                 last_name="pasteur",
                 gender="M",
                 birth_date="1822-12-27",
+                email="LPasteur@NotAReal.Email",
+                phone="1-234-555-7890",
+                ssn="123-34-0000",  # 0000 is invalid
+                group_number="fake123",
+                member_id="12345",
             ),
         ]
     )
+    pii_col_mapping = {
+        v0.first_name: "first_name",
+        v0.last_name: "last_name",
+        v0.gender: "gender",
+        v0.birth_date: "birth_date",
+        v1.first_name: "first_name",
+        v1.last_name: "last_name",
+        v1.gender: "gender",
+        v1.birth_date: "birth_date",
+        v1.email: "email",
+        v1.phone: "phone",
+        v1.ssn: "ssn",
+        v1.group_number: "group_number",
+        v1.member_id: "member_id",
+    }
+
     tokens = tokenize(
         pii,
-        col_mapping={
-            v0.first_name: "first_name",
-            v0.last_name: "last_name",
-            v0.gender: "gender",
-            v0.birth_date: "birth_date",
-            v1.first_name: "first_name",
-            v1.last_name: "last_name",
-            v1.gender: "gender",
-            v1.birth_date: "birth_date",
-        },
+        col_mapping=pii_col_mapping,
         tokens=all_tokens,
         private_key=private_key,
     )
@@ -56,109 +87,158 @@ def test_tokenize_and_transcode_opprl(
             spark.createDataFrame(
                 [
                     Row(
-                        id=1,
                         first_name="Louis",
                         last_name="Pasteur",
                         gender="male",
                         birth_date="1822-12-27",
+                        email="lpasteur@notareal.email",
+                        phone="(234) 555-7890",
+                        ssn="666-12-3456",  # 666 is invalid
+                        group_number="FAKE123",
+                        member_id="12345",
                         opprl_token_1v0="NJQZ0hNk40pt5aFitlwdx6k2Te7hMSMw1UHzNdgP1aUYbqaFbGSe3tRn4kL/OxsFJit9VhRDYRawUDYzKivYlLm2EzKCO0+nC9rJXfIFwdo=",
                         opprl_token_2v0="l6MNGG4InDZCnVX5/h3ajn1m1rCoko062CD8the2nkKO3Y0fARGZ5p4BP3pXPp3HOL603KCwpWLIXMN8fnsG3D4Tea/WOQX5kB1OQ28t2L0=",
                         opprl_token_3v0="op48PUlod5WC7PMQHJp1wEtAApfgu/1G2WuGoVDMQ6V5EZPI7X5BfpZzrdoOrA90CFVw3X79t0ygazbSFrRKx+SupOvBYFRr8ZRZmT5oz8k=",
                         opprl_token_1v1="MZYNcbue6knwp5xhJHWmYvuIxR2Lza0OhYIutY+gS/cMBYm3DAJvah0kmeCkohs6Gs2s61KiBOJ+/yFiFSYCRYZJxz2/rqg3Q/PclfyDxxQ=",
                         opprl_token_2v1="tpddR895Id1+iBdWDWRgD+uncxwnAfLJaYkJfF5L5UW2tLeqIikffQ9MLLjSsCY8lqEf8O5iqCswqCuMgn3L0MIfnlSi2BQf0Gtf9ForU/E=",
                         opprl_token_3v1="H2Wj+vmO+IrwL2/y9JzQUWYAJizTuaQe2+lJSYLUafjqJL0IUqSBP7+Rs8u6+2sb0saBBqO098TfaQTcLORkfzJ44uhTutfqng7HyD4ikw8=",
+                        opprl_token_4v1="FaTssGYTKBZMf2yUoWZAKRVm7QEKsFWzD/l8UiVOXryeQOLWtwikVxr5Ff4F3REe7YD6PW2w4gXqOqfqVJwjstSr3Oc4vMTEa5Pd1P1kzTM=",
+                        opprl_token_5v1="BbmVhYL39W+bj5w6eSm05ykaEJtBrBtFKloL+LPxsMPlbnhwnS6/jyts2faKP+P2qipUNr2ws2JPAQwe6qySQoGoaiCRHRsI1wNWTkqf+YM=",
+                        opprl_token_6v1="NUnS1Cc//mDglIQsD4Vs1TNyCEzqroio7LCvmB60RzMzICuVOpBb2aYRzKSUaAI48OKJXc/oXVcgiXXxFDhhvealbiSIsOrFLa6LGWVFNp8=",
+                        opprl_token_7v1="jQSijbniu3pNHOf4frTtxfaP/aEcDfXSCKwRFbMvq6TtaUWq/8k/4uww/y6djtlzuuPW3Rv76hmI0x41X4uCCiviZ2UHXsXUsldKJSEx5ZY=",
+                        opprl_token_8v1="/npShR3CAHHyKGpkoEjr2IWQpX1h80x+kc2ZAxzbzO+bIpbtQtGuyHCDgwi1YTz+LfCZJ/dvCrlhu1Tt3peGJfgVZhsKZr1OCMRJwD2BVG0=",
+                        opprl_token_9v1=None,
+                        opprl_token_10v1=None,
+                        opprl_token_11v1="kghwIEFPriVFGXpafPfHdOGzfWfd+T19tRfoQqKXugxVQaqVEmWih9viD5mdWWXMeoSLfcaQwyJ0WIFme/VGcGFSt1QH5btJKsYPSA6iLgc=",
+                        opprl_token_12v1="KYAbMneOypA67F1BIAmbZF0v4Aw7xRXqKvf3LCJ2nKHqRuoJWxkWnWfspHt8cF+pwNyLSOLfLddsfF58yyuz/s+G6xTXjVymbMw0ZtnCWRg=",
+                        opprl_token_13v1="LMfG/ItICop/P4wYGS0pdljnLyuQN8KgmEuUcCjpB/VQ4K0bgVZF/6Epn7oEFI6I9cFil3wqRlJtcJI7BtrmQ+oGHZKfEshNad8LjICzIaQ=",
                     ),
                     Row(
-                        id=2,
                         first_name="louis",
                         last_name="pasteur",
                         gender="M",
                         birth_date="1822-12-27",
+                        email="LPasteur@NotAReal.Email",
+                        phone="1-234-555-7890",
+                        ssn="123-34-0000",  # 0000 is invalid
+                        group_number="fake123",
+                        member_id="12345",
                         opprl_token_1v0="NJQZ0hNk40pt5aFitlwdx6k2Te7hMSMw1UHzNdgP1aUYbqaFbGSe3tRn4kL/OxsFJit9VhRDYRawUDYzKivYlLm2EzKCO0+nC9rJXfIFwdo=",
                         opprl_token_2v0="l6MNGG4InDZCnVX5/h3ajn1m1rCoko062CD8the2nkKO3Y0fARGZ5p4BP3pXPp3HOL603KCwpWLIXMN8fnsG3D4Tea/WOQX5kB1OQ28t2L0=",
                         opprl_token_3v0="op48PUlod5WC7PMQHJp1wEtAApfgu/1G2WuGoVDMQ6V5EZPI7X5BfpZzrdoOrA90CFVw3X79t0ygazbSFrRKx+SupOvBYFRr8ZRZmT5oz8k=",
                         opprl_token_1v1="MZYNcbue6knwp5xhJHWmYvuIxR2Lza0OhYIutY+gS/cMBYm3DAJvah0kmeCkohs6Gs2s61KiBOJ+/yFiFSYCRYZJxz2/rqg3Q/PclfyDxxQ=",
                         opprl_token_2v1="tpddR895Id1+iBdWDWRgD+uncxwnAfLJaYkJfF5L5UW2tLeqIikffQ9MLLjSsCY8lqEf8O5iqCswqCuMgn3L0MIfnlSi2BQf0Gtf9ForU/E=",
                         opprl_token_3v1="H2Wj+vmO+IrwL2/y9JzQUWYAJizTuaQe2+lJSYLUafjqJL0IUqSBP7+Rs8u6+2sb0saBBqO098TfaQTcLORkfzJ44uhTutfqng7HyD4ikw8=",
+                        opprl_token_4v1="FaTssGYTKBZMf2yUoWZAKRVm7QEKsFWzD/l8UiVOXryeQOLWtwikVxr5Ff4F3REe7YD6PW2w4gXqOqfqVJwjstSr3Oc4vMTEa5Pd1P1kzTM=",
+                        opprl_token_5v1="BbmVhYL39W+bj5w6eSm05ykaEJtBrBtFKloL+LPxsMPlbnhwnS6/jyts2faKP+P2qipUNr2ws2JPAQwe6qySQoGoaiCRHRsI1wNWTkqf+YM=",
+                        opprl_token_6v1="NUnS1Cc//mDglIQsD4Vs1TNyCEzqroio7LCvmB60RzMzICuVOpBb2aYRzKSUaAI48OKJXc/oXVcgiXXxFDhhvealbiSIsOrFLa6LGWVFNp8=",
+                        opprl_token_7v1="jQSijbniu3pNHOf4frTtxfaP/aEcDfXSCKwRFbMvq6TtaUWq/8k/4uww/y6djtlzuuPW3Rv76hmI0x41X4uCCiviZ2UHXsXUsldKJSEx5ZY=",
+                        opprl_token_8v1="/npShR3CAHHyKGpkoEjr2IWQpX1h80x+kc2ZAxzbzO+bIpbtQtGuyHCDgwi1YTz+LfCZJ/dvCrlhu1Tt3peGJfgVZhsKZr1OCMRJwD2BVG0=",
+                        opprl_token_9v1=None,
+                        opprl_token_10v1=None,
+                        opprl_token_11v1="kghwIEFPriVFGXpafPfHdOGzfWfd+T19tRfoQqKXugxVQaqVEmWih9viD5mdWWXMeoSLfcaQwyJ0WIFme/VGcGFSt1QH5btJKsYPSA6iLgc=",
+                        opprl_token_12v1="KYAbMneOypA67F1BIAmbZF0v4Aw7xRXqKvf3LCJ2nKHqRuoJWxkWnWfspHt8cF+pwNyLSOLfLddsfF58yyuz/s+G6xTXjVymbMw0ZtnCWRg=",
+                        opprl_token_13v1="LMfG/ItICop/P4wYGS0pdljnLyuQN8KgmEuUcCjpB/VQ4K0bgVZF/6Epn7oEFI6I9cFil3wqRlJtcJI7BtrmQ+oGHZKfEshNad8LjICzIaQ=",
                     ),
-                ]
+                ],
+                StructType(
+                    [
+                        StructField("first_name", StringType()),
+                        StructField("last_name", StringType()),
+                        StructField("gender", StringType()),
+                        StructField("birth_date", StringType()),
+                        StructField("email", StringType()),
+                        StructField("phone", StringType()),
+                        StructField("ssn", StringType()),
+                        StructField("group_number", StringType()),
+                        StructField("member_id", StringType()),
+                    ]
+                    + [StructField(t, StringType()) for t in all_token_names]
+                ),
             )
         ),
     )
-    sent_tokens = transcode_out(
-        tokens.select("id", *all_token_names),
+    ephemeral_tokens = transcode_out(
+        tokens.select(*all_token_names),
         tokens=all_tokens,
         recipient_public_key=acme_public_key,
         private_key=private_key,
     )
-    sent_tokens.show(truncate=False)
 
     assertSchemaEqual(
-        sent_tokens.schema,
-        StructType(
-            [
-                StructField("id", LongType()),
-            ]
-            + [StructField(token, StringType()) for token in all_token_names]
-        ),
+        ephemeral_tokens.schema,
+        StructType([StructField(token, StringType()) for token in all_token_names]),
     )
     # When transferring between parties, tokens from the same PII should _not_ be equal.
-    assert sent_tokens.distinct().count() == 2
+    assert ephemeral_tokens.distinct().count() == 2
 
-    result = transcode_in(
-        sent_tokens.select("id", *all_token_names),
+    tokens2 = transcode_in(
+        ephemeral_tokens.select(*all_token_names),
         tokens=all_tokens,
         private_key=acme_private_key,
     )
 
     # Check that trancryption and tokenization produce the same result.
     assertDataFrameEqual(
-        result,
+        tokens2,
         tokenize(
             pii,
-            col_mapping={
-                v0.first_name: "first_name",
-                v0.last_name: "last_name",
-                v0.gender: "gender",
-                v0.birth_date: "birth_date",
-                v1.first_name: "first_name",
-                v1.last_name: "last_name",
-                v1.gender: "gender",
-                v1.birth_date: "birth_date",
-            },
+            col_mapping=pii_col_mapping,
             tokens=all_tokens,
             private_key=acme_private_key,
-        ).select("id", *all_token_names),
+        ).select(*all_token_names),
     )
 
     # Test for token stability across changes.
     assertDataFrameEqual(
-        result,
+        tokens2,
         (
             spark.createDataFrame(
                 [
                     Row(
-                        id=1,
                         opprl_token_1v0="U/JYKVLQWSUrpvJ1D03pvKmnhlgUTFjHaPtS0pZBLSqrDCOkBOR/mDf9xFt/Cr3AB8hI00oEkuunCTvNV3zbgdz9Y0jcwiI16zn51jSkhhM=",
                         opprl_token_2v0="GDV/IQ0x6ZR/Gtl+nFOMOoKtTJ6gOHTvVJoaZZhP0BHUsymHbw+pyF9Cbjr0Q/Apa07wvN93CBnr4aBi8vvCDxi0Qg8x8wJf+yZZpwFR3Dw=",
                         opprl_token_3v0="cOrhMGV6oO3Vt8w3vV1K4TzvNYlkZZ9JOj9/53IGkD7vgce0I13uOrDFCcJEXD1qEa4Mm1Nimq4sprd8tFrdDHRDCOeZBE2Gs4DEEt7LhL0=",
                         opprl_token_1v1="iVev4mqFAJhERbOyS1VCf37RXoyAFpbJDfapJOLpMaP5enFICVhHwaN6UlxhtBh8+nmYMJBCNFXgFEvOYUpohivogEBnM2AQHlmQKPDLG2Y=",
                         opprl_token_2v1="dE+z4cJ5Av0XdAJTYRYsCZH7XsBIQY/8b1TrpzmA6HjQbbJKBwwKV/dS0BRKbwSijCCcGcrmFDclP7qDbfn6sLxlkP70tdo1dOsKIfrwhMw=",
                         opprl_token_3v1="TK4/1PmoAR2Xu8jCxSAgMoEXmS5YsTbjSYiM6mTX+zFnXH9aP+JJOUZuEVEiM0nKdwVhRVUjbRi6FVRZjK7kCMjTP1SNIjmhICS4u+o8W0Y=",
-                    ),
-                    Row(
-                        id=2,
-                        opprl_token_1v0="U/JYKVLQWSUrpvJ1D03pvKmnhlgUTFjHaPtS0pZBLSqrDCOkBOR/mDf9xFt/Cr3AB8hI00oEkuunCTvNV3zbgdz9Y0jcwiI16zn51jSkhhM=",
-                        opprl_token_2v0="GDV/IQ0x6ZR/Gtl+nFOMOoKtTJ6gOHTvVJoaZZhP0BHUsymHbw+pyF9Cbjr0Q/Apa07wvN93CBnr4aBi8vvCDxi0Qg8x8wJf+yZZpwFR3Dw=",
-                        opprl_token_3v0="cOrhMGV6oO3Vt8w3vV1K4TzvNYlkZZ9JOj9/53IGkD7vgce0I13uOrDFCcJEXD1qEa4Mm1Nimq4sprd8tFrdDHRDCOeZBE2Gs4DEEt7LhL0=",
-                        opprl_token_1v1="iVev4mqFAJhERbOyS1VCf37RXoyAFpbJDfapJOLpMaP5enFICVhHwaN6UlxhtBh8+nmYMJBCNFXgFEvOYUpohivogEBnM2AQHlmQKPDLG2Y=",
-                        opprl_token_2v1="dE+z4cJ5Av0XdAJTYRYsCZH7XsBIQY/8b1TrpzmA6HjQbbJKBwwKV/dS0BRKbwSijCCcGcrmFDclP7qDbfn6sLxlkP70tdo1dOsKIfrwhMw=",
-                        opprl_token_3v1="TK4/1PmoAR2Xu8jCxSAgMoEXmS5YsTbjSYiM6mTX+zFnXH9aP+JJOUZuEVEiM0nKdwVhRVUjbRi6FVRZjK7kCMjTP1SNIjmhICS4u+o8W0Y=",
-                    ),
+                        opprl_token_4v1="wGwtW6zPRiM5ySg9SDruvsUh1trvMPsPHeh9mxhDoFslduxS2MCUWgOwmzx1aO4wtzoM3Oa4yobmWRr0/1DjXsVWzoNY1y3NefTWm/4/hh0=",
+                        opprl_token_5v1="AZ2fSNNo37AnL2tI0N6eK6tWXHZ0dn2rYJMrfGzbNZdqjLUPNKieCth/AfvRCwGGx6P1GS6f+iTQvmoc+wZg3XRI32v+rMPvgOAr6EAFvzo=",
+                        opprl_token_6v1="X8rEpi1xpHi7ItQpTuSQqssPKCHN0xGyj78AjNewHuJT1M67IicOG92ojcxN34lX/+jlI0nqXgRAgVmKO9Tfe8Vvo8EVsYbfkLCPai0IY78=",
+                        opprl_token_7v1="TxsgzlFWe9loSlFmsh92HCtu5CRUd+6TD6dL6woFbwuCcrm10spPQhAhFEyM2XAQNIIIbA4VyBJIpNvMrTbRGEgGK7SDgpAGcjxCagcWElA=",
+                        opprl_token_8v1="9VJvJ4IF1wDPP4ySGgrkfbVYDnoHkQLGmIMWowZ7+XocuTc07SO+hZkFROHbZsWSXTIkQ7VS8fwk56OGgdHxIxI5SQpVAOCVaFywhLx8M1E=",
+                        opprl_token_9v1=None,
+                        opprl_token_10v1=None,
+                        opprl_token_11v1="OvQjwdmG2zuN+yru8dWZ3yL1W0Uv6qMF7HSbuPkCiWORmsvSoRKzTQV2eBlj5Ds+VnZlzgfykbuo4H1jh7a53UmdnK1e/tLi775vqThKRy8=",
+                        opprl_token_12v1="5RfmceqAl0/cPOGt/gRlM/9VCnhJsVnLJw0VpNxtgiUQd3Q0gsLvNZGomyldg2QQzcNzMp+cVJ+qy0KM+B36tzALOh/M+nKJDZoPugUn1ls=",
+                        opprl_token_13v1="fArMtZhWOrpOeTSmAjX7heNXhr6OtwI2rBpa+ERNEWTYotD3VR8Pmiws95pvWCPn24Sc+vjz2IHF80DeXi4C6DRMQxqnhpedUIl5KgfEo5A=",
+                    )
                 ]
+                * 2,
+                StructType([StructField(t, StringType()) for t in all_token_names]),
             )
         ),
     )
+
+
+def test_identity_attribute(spark: SparkSession, private_key: bytes):
+    pii = spark.createDataFrame(
+        [
+            Row(
+                email="NotA@Real.Email",
+                hem="1f3e6adb230cbd09a16662c9395050fe63f79bd2759305525a185cfda3998e79",
+            ),
+        ]
+    )
+    token_from_email = tokenize(pii, {v1.email: "email"}, [v1.token12], private_key).head()
+    token_from_hem = tokenize(pii, {v1.hem: "hem"}, [v1.token12], private_key).head()
+    token_from_identity = tokenize(
+        pii, {IdentityAttribute("opprl.v1.email.sha2"): "hem"}, [v1.token12], private_key
+    ).head()
+    assert token_from_email
+    assert token_from_hem
+    assert token_from_identity
+    assert token_from_email == token_from_hem == token_from_identity
 
 
 class _Zip3Attribute(PiiAttribute):
@@ -171,7 +251,7 @@ class _Zip3Attribute(PiiAttribute):
 
 
 class ZipcodeAttribute(PiiAttribute):
-    def transform(self, column, dtype):
+    def transform(self, column, _):
         return regexp_replace(column, "[^0-9]", "")
 
     @property
@@ -226,7 +306,9 @@ def test_custom_pii_and_token(spark: SparkSession, private_key: bytes):
                 zipAttr: "zipcode",
             },
             tokens=[
-                Token("custom_token", v1.protocol, (v1.last_name, zipAttr.zip3)),
+                Token(
+                    "custom_token", v1.protocol, (v1.last_name.attr_id, zipAttr.zip3.attr_id)
+                ),
                 v1.token1,
             ],
             private_key=private_key,


### PR DESCRIPTION
The PR replaces #23 which added new tokens to carduus and OPPRL version 0. To encourage users to use OPPRL version 1 (with the improved key derivation function) this add the new tokens to spindle-token.