### PR TITLE
Add Spark-free OPPRL v2 token metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `spindle-token` will be documented in this file.
 
+## Unreleased
+
+### Packaging and Metadata
+
+- Added Spark-free OPPRL v2 token metadata so downstream apps can inspect
+  supported token names and attribute IDs without installing the Spark optional
+  dependency.
+- Kept OPPRL v2 runtime token definitions backed by the same ordered metadata
+  used by the new metadata API.
+
 ## 2.2.0
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ pip install "spindle-token[spark]"
 The base `spindle-token` package remains importable without Spark so non-Spark
 environments and serverless dependency checks do not need to pull in PySpark.
 
+Applications that only need OPPRL token metadata can inspect supported V2 token
+names without Spark:
+
+```python
+from spindle_token.opprl.metadata import get_opprl_v2_tokens
+
+token_columns = {token.token_id: token.name for token in get_opprl_v2_tokens()}
+```
+
 The pre-v1.0 versions of this library were published under the name "carduus" and the deprecated APIs can be found [here](https://token.spindlehealth.com/carduus/api/).
 
 ## Getting Started

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,8 @@
-The spindle-token API is broken up into 3 namespaces: 
+The spindle-token API is broken up into 4 namespaces: 
 
 1. The top-level `spindle_token` module containing the most commonly used public functions.
 1. An OPPRL module containing implementations of every OPPRL protocol version, including PII normalization, token specifications, and cryptographic transformations.
+1. An OPPRL metadata module exposing Spark-free token metadata for lightweight schema inspection.
 1. A module of `core` abstractions than can be extended in advanced use cases to add additional functionality.
 
 ## ::: spindle_token
@@ -12,6 +13,13 @@ The spindle-token API is broken up into 3 namespaces:
       show_source: false
 
 ## ::: spindle_token.opprl
+    handler: python
+    options:
+      members_order: source
+      show_root_heading: true
+      show_source: false
+
+## ::: spindle_token.opprl.metadata
     handler: python
     options:
       members_order: source

--- a/src/spindle_token/opprl/_v2_definitions.py
+++ b/src/spindle_token/opprl/_v2_definitions.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["OpprlTokenDefinition", "OPPRL_V2_TOKEN_DEFINITIONS", "get_opprl_v2_definition"]
+
+
+@dataclass(frozen=True)
+class OpprlTokenDefinition:
+    protocol: str
+    version: str
+    token_id: str
+    name: str
+    attribute_ids: tuple[str, ...]
+
+
+OPPRL_V2_TOKEN_DEFINITIONS: tuple[OpprlTokenDefinition, ...] = (
+    OpprlTokenDefinition(
+        protocol="opprl",
+        version="v2",
+        token_id="token1",
+        name="opprl_token_1v2",
+        attribute_ids=(
+            "opprl.v2.first.initial",
+            "opprl.v2.last",
+            "opprl.v2.gender",
+            "opprl.v2.birth_date",
+        ),
+    ),
+    OpprlTokenDefinition(
+        protocol="opprl",
+        version="v2",
+        token_id="token2",
+        name="opprl_token_2v2",
+        attribute_ids=(
+            "opprl.v2.first.soundex",
+            "opprl.v2.last.soundex",
+            "opprl.v2.gender",
+            "opprl.v2.birth_date",
+        ),
+    ),
+    OpprlTokenDefinition(
+        protocol="opprl",
+        version="v2",
+        token_id="token3",
+        name="opprl_token_3v2",
+        attribute_ids=(
+            "opprl.v2.first.metaphone",
+            "opprl.v2.last.metaphone",
+            "opprl.v2.gender",
+            "opprl.v2.birth_date",
+        ),
+    ),
+    OpprlTokenDefinition(
+        protocol="opprl",
+        version="v2",
+        token_id="token4",
+        name="opprl_token_4v2",
+        attribute_ids=(
+            "opprl.v2.first.initial",
+            "opprl.v2.last",
+            "opprl.v2.birth_date",
+        ),
+    ),
+    OpprlTokenDefinition(
+        protocol="opprl",
+        version="v2",
+        token_id="token5",
+        name="opprl_token_5v2",
+        attribute_ids=(
+            "opprl.v2.first.soundex",
+            "opprl.v2.last.soundex",
+            "opprl.v2.birth_date",
+        ),
+    ),
+    OpprlTokenDefinition(
+        protocol="opprl",
+        version="v2",
+        token_id="token6",
+        name="opprl_token_6v2",
+        attribute_ids=(
+            "opprl.v2.first.metaphone",
+            "opprl.v2.last.metaphone",
+            "opprl.v2.birth_date",
+        ),
+    ),
+    OpprlTokenDefinition(
+        protocol="opprl",
+        version="v2",
+        token_id="token7",
+        name="opprl_token_7v2",
+        attribute_ids=(
+            "opprl.v2.first",
+            "opprl.v2.phone",
+        ),
+    ),
+    OpprlTokenDefinition(
+        protocol="opprl",
+        version="v2",
+        token_id="token8",
+        name="opprl_token_8v2",
+        attribute_ids=(
+            "opprl.v2.birth_date",
+            "opprl.v2.phone",
+        ),
+    ),
+    OpprlTokenDefinition(
+        protocol="opprl",
+        version="v2",
+        token_id="token9",
+        name="opprl_token_9v2",
+        attribute_ids=(
+            "opprl.v2.first",
+            "opprl.v2.ssn",
+        ),
+    ),
+    OpprlTokenDefinition(
+        protocol="opprl",
+        version="v2",
+        token_id="token10",
+        name="opprl_token_10v2",
+        attribute_ids=(
+            "opprl.v2.birth_date",
+            "opprl.v2.ssn",
+        ),
+    ),
+    OpprlTokenDefinition(
+        protocol="opprl",
+        version="v2",
+        token_id="token11",
+        name="opprl_token_11v2",
+        attribute_ids=("opprl.v2.email",),
+    ),
+    OpprlTokenDefinition(
+        protocol="opprl",
+        version="v2",
+        token_id="token12",
+        name="opprl_token_12v2",
+        attribute_ids=("opprl.v2.email.sha2",),
+    ),
+    OpprlTokenDefinition(
+        protocol="opprl",
+        version="v2",
+        token_id="token13",
+        name="opprl_token_13v2",
+        attribute_ids=(
+            "opprl.v2.group_number",
+            "opprl.v2.member_id",
+        ),
+    ),
+)
+
+_OPPRL_V2_DEFINITIONS_BY_ID = {
+    definition.token_id: definition for definition in OPPRL_V2_TOKEN_DEFINITIONS
+}
+
+
+def get_opprl_v2_definition(token_id: str) -> OpprlTokenDefinition:
+    return _OPPRL_V2_DEFINITIONS_BY_ID[token_id]

--- a/src/spindle_token/opprl/metadata.py
+++ b/src/spindle_token/opprl/metadata.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from spindle_token.opprl._v2_definitions import OPPRL_V2_TOKEN_DEFINITIONS
+
+__all__ = ["OpprlTokenMetadata", "get_opprl_v2_tokens", "get_opprl_v2_token_by_name"]
+
+
+@dataclass(frozen=True)
+class OpprlTokenMetadata:
+    protocol: str
+    version: str
+    token_id: str
+    name: str
+    attribute_ids: tuple[str, ...]
+
+
+_OPPRL_V2_TOKEN_METADATA = tuple(
+    OpprlTokenMetadata(
+        protocol=definition.protocol,
+        version=definition.version,
+        token_id=definition.token_id,
+        name=definition.name,
+        attribute_ids=definition.attribute_ids,
+    )
+    for definition in OPPRL_V2_TOKEN_DEFINITIONS
+)
+
+_OPPRL_V2_TOKEN_METADATA_BY_NAME = {
+    metadata.name: metadata for metadata in _OPPRL_V2_TOKEN_METADATA
+}
+
+
+def get_opprl_v2_tokens() -> tuple[OpprlTokenMetadata, ...]:
+    return _OPPRL_V2_TOKEN_METADATA
+
+
+def get_opprl_v2_token_by_name(name: str) -> OpprlTokenMetadata | None:
+    return _OPPRL_V2_TOKEN_METADATA_BY_NAME.get(name)

--- a/src/spindle_token/opprl/v2.py
+++ b/src/spindle_token/opprl/v2.py
@@ -32,6 +32,7 @@ from spindle_token.opprl._common import (
     PhoneNumberAttribute,
     SsnAttribute,
 )
+from spindle_token.opprl._v2_definitions import get_opprl_v2_definition
 
 __all__ = ["OpprlV2"]
 
@@ -89,6 +90,11 @@ class _ProtocolFactoryV2(TokenProtocolFactory[_ProtocolV2]):
 
     def bind(self, private_key: bytes, recipient_public_key: bytes | None) -> _ProtocolV2:
         return _ProtocolV2(private_key, recipient_public_key)
+
+
+def _token(token_id: str, protocol: TokenProtocolFactory) -> Token:
+    definition = get_opprl_v2_definition(token_id)
+    return Token(definition.name, protocol, definition.attribute_ids)
 
 
 class OpprlV2:
@@ -176,122 +182,28 @@ class OpprlV2:
 
     protocol: ClassVar[TokenProtocolFactory] = _ProtocolFactoryV2("opprl.v2")
 
-    token1: ClassVar[Token] = Token(
-        "opprl_token_1v2",
-        protocol,
-        (
-            first_name.initial.attr_id,
-            last_name.attr_id,
-            gender.attr_id,
-            birth_date.attr_id,
-        ),
-    )
+    token1: ClassVar[Token] = _token("token1", protocol)
 
-    token2: ClassVar[Token] = Token(
-        "opprl_token_2v2",
-        protocol,
-        (
-            first_name.soundex.attr_id,
-            last_name.soundex.attr_id,
-            gender.attr_id,
-            birth_date.attr_id,
-        ),
-    )
+    token2: ClassVar[Token] = _token("token2", protocol)
 
-    token3: ClassVar[Token] = Token(
-        "opprl_token_3v2",
-        protocol,
-        (
-            first_name.metaphone.attr_id,
-            last_name.metaphone.attr_id,
-            gender.attr_id,
-            birth_date.attr_id,
-        ),
-    )
+    token3: ClassVar[Token] = _token("token3", protocol)
 
-    token4: ClassVar[Token] = Token(
-        "opprl_token_4v2",
-        protocol,
-        (
-            first_name.initial.attr_id,
-            last_name.attr_id,
-            birth_date.attr_id,
-        ),
-    )
+    token4: ClassVar[Token] = _token("token4", protocol)
 
-    token5: ClassVar[Token] = Token(
-        "opprl_token_5v2",
-        protocol,
-        (
-            first_name.soundex.attr_id,
-            last_name.soundex.attr_id,
-            birth_date.attr_id,
-        ),
-    )
+    token5: ClassVar[Token] = _token("token5", protocol)
 
-    token6: ClassVar[Token] = Token(
-        "opprl_token_6v2",
-        protocol,
-        (
-            first_name.metaphone.attr_id,
-            last_name.metaphone.attr_id,
-            birth_date.attr_id,
-        ),
-    )
+    token6: ClassVar[Token] = _token("token6", protocol)
 
-    token7: ClassVar[Token] = Token(
-        "opprl_token_7v2",
-        protocol,
-        (
-            first_name.attr_id,
-            phone.attr_id,
-        ),
-    )
+    token7: ClassVar[Token] = _token("token7", protocol)
 
-    token8: ClassVar[Token] = Token(
-        "opprl_token_8v2",
-        protocol,
-        (
-            birth_date.attr_id,
-            phone.attr_id,
-        ),
-    )
+    token8: ClassVar[Token] = _token("token8", protocol)
 
-    token9: ClassVar[Token] = Token(
-        "opprl_token_9v2",
-        protocol,
-        (
-            first_name.attr_id,
-            ssn.attr_id,
-        ),
-    )
+    token9: ClassVar[Token] = _token("token9", protocol)
 
-    token10: ClassVar[Token] = Token(
-        "opprl_token_10v2",
-        protocol,
-        (
-            birth_date.attr_id,
-            ssn.attr_id,
-        ),
-    )
+    token10: ClassVar[Token] = _token("token10", protocol)
 
-    token11: ClassVar[Token] = Token(
-        "opprl_token_11v2",
-        protocol,
-        (email.attr_id,),
-    )
+    token11: ClassVar[Token] = _token("token11", protocol)
 
-    token12: ClassVar[Token] = Token(
-        "opprl_token_12v2",
-        protocol,
-        (hem.attr_id,),
-    )
+    token12: ClassVar[Token] = _token("token12", protocol)
 
-    token13: ClassVar[Token] = Token(
-        "opprl_token_13v2",
-        protocol,
-        (
-            group_number.attr_id,
-            member_id.attr_id,
-        ),
-    )
+    token13: ClassVar[Token] = _token("token13", protocol)

--- a/tests/test_opprl_metadata.py
+++ b/tests/test_opprl_metadata.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+from spindle_token.opprl.metadata import (
+    get_opprl_v2_token_by_name,
+    get_opprl_v2_tokens,
+)
+from spindle_token.opprl.v2 import OpprlV2
+
+
+def test_opprl_v2_metadata_imports_without_pyspark() -> None:
+    project_src = Path(__file__).resolve().parents[1] / "src"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = (
+        str(project_src)
+        if not env.get("PYTHONPATH")
+        else str(project_src) + os.pathsep + env["PYTHONPATH"]
+    )
+
+    code = textwrap.dedent("""
+        import importlib.abc
+        import sys
+
+        class BlockPySpark(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path, target=None):
+                if fullname == "pyspark" or fullname.startswith("pyspark."):
+                    raise ModuleNotFoundError("No module named 'pyspark'")
+                return None
+
+        sys.meta_path.insert(0, BlockPySpark())
+
+        from spindle_token.opprl.metadata import (
+            get_opprl_v2_token_by_name,
+            get_opprl_v2_tokens,
+        )
+
+        tokens = get_opprl_v2_tokens()
+        assert len(tokens) == 13
+        assert get_opprl_v2_token_by_name("opprl_token_11v2").token_id == "token11"
+        assert "pyspark" not in sys.modules
+        assert "pyspark.sql" not in sys.modules
+        assert "spindle_token._spark" not in sys.modules
+        assert "spindle_token.opprl.v2" not in sys.modules
+        """)
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_get_opprl_v2_token_by_name_returns_none_for_unknown_name() -> None:
+    assert get_opprl_v2_token_by_name("unknown") is None
+
+
+def test_opprl_v2_metadata_matches_runtime_tokens_in_order() -> None:
+    runtime_tokens = {
+        "token1": OpprlV2.token1,
+        "token2": OpprlV2.token2,
+        "token3": OpprlV2.token3,
+        "token4": OpprlV2.token4,
+        "token5": OpprlV2.token5,
+        "token6": OpprlV2.token6,
+        "token7": OpprlV2.token7,
+        "token8": OpprlV2.token8,
+        "token9": OpprlV2.token9,
+        "token10": OpprlV2.token10,
+        "token11": OpprlV2.token11,
+        "token12": OpprlV2.token12,
+        "token13": OpprlV2.token13,
+    }
+
+    metadata = get_opprl_v2_tokens()
+
+    assert tuple(token.token_id for token in metadata) == tuple(runtime_tokens)
+    for token_metadata in metadata:
+        runtime_token = runtime_tokens[token_metadata.token_id]
+        assert token_metadata.protocol == "opprl"
+        assert token_metadata.version == "v2"
+        assert token_metadata.name == runtime_token.name
+        assert token_metadata.attribute_ids == tuple(runtime_token.attribute_ids)


### PR DESCRIPTION
## Summary

  Adds a lightweight OPPRL v2 metadata API that downstream applications can import without installing the Spark optional dependency. The new API exposes supported token IDs, output column names, and ordered attribute IDs for schema inspection use cases such as Databricks app transcode workflows.

  ## Changes

  - Add `spindle_token.opprl.metadata` with `OpprlTokenMetadata`, `get_opprl_v2_tokens()`, and `get_opprl_v2_token_by_name()`.
  - Add internal Spark-free OPPRL v2 token definitions in `spindle_token.opprl._v2_definitions`.
  - Refactor `OpprlV2.token1` through `token13` to use the same ordered definitions, preventing runtime token metadata and the lightweight API from
  drifting.
  - Document the metadata API in README/API docs and add an unreleased changelog entry.
  - Add tests for no-PySpark imports and exact ordered parity between metadata and runtime `OpprlV2` tokens.

  ## Compatibility

  This is additive and does not make tokenization or transcoding Spark-free. Existing Spark-backed APIs continue to use the normal `OpprlV2` token objects.

  Token generation should remain unchanged: the refactor preserves exact token names, protocol factory assignment, and ordered `attribute_ids`. The ordered parity test and existing v2 golden token tests guard that contract.